### PR TITLE
Use the -checkpoint_count flag to support the file checkpoint to reduce read and write unmodified file chunks in local disk mode

### DIFF
--- a/sync/remote_server_sync.go
+++ b/sync/remote_server_sync.go
@@ -29,7 +29,7 @@ type remoteServerSync struct {
 
 // NewRemoteServerSync create an instance of remoteServerSync execute send file change message
 func NewRemoteServerSync(source, dest core.VFS, enableTLS bool, certFile string, keyFile string, users []*auth.User, enableLogicallyDelete bool, chunkSize int64, checkpointCount int) (Sync, error) {
-	ds, err := newDiskSync(source, dest, enableLogicallyDelete)
+	ds, err := newDiskSync(source, dest, enableLogicallyDelete, chunkSize, checkpointCount)
 	if err != nil {
 		return nil, err
 	}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -31,7 +31,7 @@ type Sync interface {
 // NewSync auto create an instance of the expected sync according to source and dest
 func NewSync(source core.VFS, dest core.VFS, enableTLS bool, certFile string, keyFile string, users []*auth.User, enableLogicallyDelete bool, chunkSize int64, checkpointCount int) (Sync, error) {
 	if source.IsDisk() && dest.IsDisk() {
-		return NewDiskSync(source, dest, enableLogicallyDelete)
+		return NewDiskSync(source, dest, enableLogicallyDelete, chunkSize, checkpointCount)
 	} else if source.Is(core.RemoteDisk) {
 		return NewRemoteSync(source, dest, enableTLS, certFile, keyFile, users, enableLogicallyDelete, chunkSize, checkpointCount)
 	} else if dest.Is(core.RemoteDisk) {


### PR DESCRIPTION
It looks slower when the big file changes because it causes more reading but less writing.