### PR TITLE
Fix compile error, syscall.Timespec's members are int32 on linux 386

### DIFF
--- a/fs/fs_linux.go
+++ b/fs/fs_linux.go
@@ -11,9 +11,10 @@ func GetFileTimeBySys(sys any) (cTime time.Time, aTime time.Time, mTime time.Tim
 	if sys != nil {
 		attr := sys.(*syscall.Stat_t)
 		if attr != nil {
-			cTime = time.Unix(attr.Ctim.Sec, attr.Ctim.Nsec)
-			aTime = time.Unix(attr.Atim.Sec, attr.Atim.Nsec)
-			mTime = time.Unix(attr.Mtim.Sec, attr.Mtim.Nsec)
+			// fix compile error, syscall.Timespec's members are int32 on linux 386
+			cTime = time.Unix(int64(attr.Ctim.Sec), int64(attr.Ctim.Nsec))
+			aTime = time.Unix(int64(attr.Atim.Sec), int64(attr.Atim.Nsec))
+			mTime = time.Unix(int64(attr.Mtim.Sec), int64(attr.Mtim.Nsec))
 		}
 	} else {
 		err = errors.New("file sys info is nil")


### PR DESCRIPTION
Fixes #34