### PR TITLE
Fix zip slip vulnerability

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,74 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 18 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/encrypt/decrypt_reader.go
+++ b/encrypt/decrypt_reader.go
@@ -33,7 +33,6 @@ func (r *decryptReader) WriteTo(path string) (err error) {
 
 		// path is directory
 		if file.FileInfo().IsDir() {
-
 			err = os.MkdirAll(outPath, os.ModePerm)
 			if err != nil {
 				return err

--- a/encrypt/decrypt_reader.go
+++ b/encrypt/decrypt_reader.go
@@ -4,11 +4,10 @@ import (
 	"archive/zip"
 	"bufio"
 	"fmt"
-	iofs "io/fs"
+	"io/fs"
 	"os"
 	"path/filepath"
 
-	"github.com/no-src/gofs/fs"
 	"github.com/no-src/log"
 )
 
@@ -19,17 +18,13 @@ type decryptReader struct {
 
 func (r *decryptReader) WriteTo(path string) (err error) {
 	for _, file := range r.zrc.File {
-		outPath := filepath.Join(path, file.Name)
-
 		// check zip slip
-		var isSub bool
-		isSub, err = fs.IsSub(path, outPath)
-		if err != nil {
-			return err
-		}
-		if !isSub {
+		isValid := fs.ValidPath(file.Name)
+		if !isValid {
 			return fmt.Errorf("illegal file path => %s", file.Name)
 		}
+
+		outPath := filepath.Join(path, file.Name)
 
 		// path is directory
 		if file.FileInfo().IsDir() {
@@ -41,7 +36,7 @@ func (r *decryptReader) WriteTo(path string) (err error) {
 		}
 
 		// path is a file
-		var f iofs.File
+		var f fs.File
 		f, err = r.zrc.Open(file.Name)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #48

For example, create a malicious archive file.

```bash
mkdir ../zipslip
touch ../zipslip/file.txt
zip zipslip.zip ../zipslip/*
```