### PR TITLE
Implement the CBool by atomic.Bool in go1.19

### DIFF
--- a/internal/cbool/cbool_test.go
+++ b/internal/cbool/cbool_test.go
@@ -43,14 +43,11 @@ func TestCBool_Concurrent(t *testing.T) {
 			wg.Done()
 		}()
 
-	}
-	for i := 0; i < count; i++ {
 		go func() {
 			cb.Set(true)
 			wg.Done()
 		}()
-	}
-	for i := 0; i < count; i++ {
+
 		go func() {
 			<-cb.SetC(true)
 			wg.Done()


### PR DESCRIPTION
go1.18.10 windows/amd64

```
goos: windows
goarch: amd64
pkg: github.com/no-src/gofs/internal/cbool
cpu: Intel(R) Core(TM) i7-6800K CPU @ 3.40GHz
BenchmarkCBool
BenchmarkCBool-12       23704098                60.44 ns/op            0 B/op               0 allocs/op
```

go1.19.5 windows/amd64

```
goos: windows
goarch: amd64
pkg: github.com/no-src/gofs/internal/cbool
cpu: Intel(R) Core(TM) i7-6800K CPU @ 3.40GHz
BenchmarkCBool
BenchmarkCBool-12       113797044                9.814 ns/op           0 B/op               0 allocs/op
```