### PR TITLE
fix: invalid ssh key file

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -442,7 +442,7 @@ $ gofs -source="./source" -dest="rs://127.0.0.1:8105?local_sync_disabled=false&p
 启动一个SFTP推送客户端，将发生变更的文件同步到SFTP服务器
 
 ```bash
-$ gofs -source="./source" -dest="sftp://127.0.0.1:22?local_sync_disabled=false&path=./dest&remote_path=/gofs_sftp_server" -users="sftp_user|sftp_pwd" -tls_cert_file=cert.pem
+$ gofs -source="./source" -dest="sftp://127.0.0.1:22?local_sync_disabled=false&path=./dest&remote_path=/gofs_sftp_server&ssh_user=sftp_user&ssh_pass=sftp_pwd" -tls_cert_file=cert.pem
 ```
 
 ### SFTP拉取客户端
@@ -450,7 +450,7 @@ $ gofs -source="./source" -dest="sftp://127.0.0.1:22?local_sync_disabled=false&p
 启动一个SFTP拉取客户端，将文件从SFTP服务器拉到本地目标路径
 
 ```bash
-$ gofs -source="sftp://127.0.0.1:22?remote_path=/gofs_sftp_server" -dest="./dest" -users="sftp_user|sftp_pwd" -sync_once
+$ gofs -source="sftp://127.0.0.1:22?remote_path=/gofs_sftp_server&ssh_user=sftp_user&ssh_pass=sftp_pwd" -dest="./dest" -sync_once
 ```
 
 ### MinIO推送客户端

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ $ gofs -source="./source" -dest="rs://127.0.0.1:8105?local_sync_disabled=false&p
 Start a SFTP push client to sync change files to the SFTP server.
 
 ```bash
-$ gofs -source="./source" -dest="sftp://127.0.0.1:22?local_sync_disabled=false&path=./dest&remote_path=/gofs_sftp_server" -users="sftp_user|sftp_pwd"
+$ gofs -source="./source" -dest="sftp://127.0.0.1:22?local_sync_disabled=false&path=./dest&remote_path=/gofs_sftp_server&ssh_user=sftp_user&ssh_pass=sftp_pwd"
 ```
 
 ### SFTP Pull Client
@@ -470,7 +470,7 @@ $ gofs -source="./source" -dest="sftp://127.0.0.1:22?local_sync_disabled=false&p
 Start a SFTP pull client to pull the files from the SFTP server to the local destination path.
 
 ```bash
-$ gofs -source="sftp://127.0.0.1:22?remote_path=/gofs_sftp_server" -dest="./dest" -users="sftp_user|sftp_pwd" -sync_once
+$ gofs -source="sftp://127.0.0.1:22?remote_path=/gofs_sftp_server&ssh_user=sftp_user&ssh_pass=sftp_pwd" -dest="./dest" -sync_once
 ```
 
 ### MinIO Push Client

--- a/conf/config.go
+++ b/conf/config.go
@@ -33,9 +33,6 @@ type Config struct {
 	MaxTranRate           int64    `json:"max_tran_rate" yaml:"max_tran_rate"`
 	DryRun                bool     `json:"dry_run" yaml:"dry_run"`
 
-	// ssh
-	SSHKey string `json:"ssh_key" yaml:"ssh_key"`
-
 	// file monitor
 	EnableSyncDelay bool          `json:"sync_delay" yaml:"sync_delay"`
 	SyncDelayEvents int           `json:"sync_delay_events" yaml:"sync_delay_events"`

--- a/conf/example/gofs-remote-client.json
+++ b/conf/example/gofs-remote-client.json
@@ -14,7 +14,6 @@
   "progress": false,
   "max_tran_rate": 0,
   "dry_run": false,
-  "ssh_key": "",
   "sync_delay": false,
   "sync_delay_events": 10,
   "sync_delay_time": "30s",

--- a/conf/example/gofs-remote-server.yaml
+++ b/conf/example/gofs-remote-server.yaml
@@ -13,7 +13,6 @@ checksum_algorithm: md5
 progress: false
 max_tran_rate: 0
 dry_run: false
-ssh_key: ""
 sync_delay: false
 sync_delay_events: 10
 sync_delay_time: 30s

--- a/core/ssh_config.go
+++ b/core/ssh_config.go
@@ -1,0 +1,15 @@
+package core
+
+// SSHConfig the config info for SSH authentication
+type SSHConfig struct {
+	// Username the username for SSH
+	Username string
+	// Password the password for SSH
+	Password string
+	// Key the key file for SSH
+	Key string
+	// KeyPass the passphrase for the key file
+	KeyPass string
+	// HostKey the host key file used to validate the server's host key
+	HostKey string
+}

--- a/core/vfs_test.go
+++ b/core/vfs_test.go
@@ -13,8 +13,8 @@ const (
 	testVFSServerPath                     = "rs://127.0.0.1:8105?mode=server&local_sync_disabled=true&path=./source&fs_server=https://127.0.0.1"
 	testVFSServerPathWithNoPort           = "rs://127.0.0.1?mode=server&local_sync_disabled=true&path=./source&fs_server=https://127.0.0.1"
 	testVFSServerPathWithNoSchemeFsServer = "rs://127.0.0.1:8105?mode=server&local_sync_disabled=true&path=./source&fs_server=127.0.0.1"
-	testVFSSFTPDestPath                   = "sftp://127.0.0.1:22?mode=server&local_sync_disabled=true&path=./source&remote_path=/home/remote/dest"
-	testVFSSFTPDestPathWithNoPort         = "sftp://127.0.0.1?mode=server&local_sync_disabled=true&path=./source&remote_path=/home/remote/dest"
+	testVFSSFTPDestPath                   = "sftp://127.0.0.1:22?mode=server&local_sync_disabled=true&path=./source&remote_path=/home/remote/dest&ssh_user=sftp_user&ssh_pass=sftp_pwd&ssh_key=./id_rsa&ssh_key_pass=123456&ssh_host_key=/root/.ssh/known_hosts"
+	testVFSSFTPDestPathWithNoPort         = "sftp://127.0.0.1?mode=server&local_sync_disabled=true&path=./source&remote_path=/home/remote/dest&ssh_user=sftp_user&ssh_pass=sftp_pwd&ssh_key=./id_rsa&ssh_key_pass=123456&ssh_host_key=/root/.ssh/known_hosts"
 	testVFSMinIODestPath                  = "minio://127.0.0.1:9000?mode=server&local_sync_disabled=true&path=./source&remote_path=/home/remote/dest&secure=true"
 	testVFSMinIODestPathWithNoPort        = "minio://127.0.0.1?mode=server&local_sync_disabled=true&path=./source&remote_path=/home/remote/dest&secure=false"
 )
@@ -254,6 +254,13 @@ func compareVFS(t *testing.T, expect, actual VFS) {
 	assert(t, expect.FsServer() == actual.FsServer(), "compare vfs FsServer error, expect:%s, actual:%s", expect.FsServer(), actual.FsServer())
 	assert(t, expect.LocalSyncDisabled() == actual.LocalSyncDisabled(), "compare vfs LocalSyncDisabled error, expect:%v, actual:%v", expect.LocalSyncDisabled(), actual.LocalSyncDisabled())
 	assert(t, expect.Secure() == actual.Secure(), "compare vfs Secure error, expect:%v, actual:%v", expect.Secure(), actual.Secure())
+	expectSSHConfig := expect.SSHConfig()
+	actualSSHConfig := actual.SSHConfig()
+	assert(t, expectSSHConfig.Username == actualSSHConfig.Username, "compare vfs SSHConfig.Username error, expect:%v, actual:%v", expectSSHConfig.Username, actualSSHConfig.Username)
+	assert(t, expectSSHConfig.Password == actualSSHConfig.Password, "compare vfs SSHConfig.Password error, expect:%v, actual:%v", expectSSHConfig.Password, actualSSHConfig.Password)
+	assert(t, expectSSHConfig.Key == actualSSHConfig.Key, "compare vfs SSHConfig.Key error, expect:%v, actual:%v", expectSSHConfig.Key, actualSSHConfig.Key)
+	assert(t, expectSSHConfig.KeyPass == actualSSHConfig.KeyPass, "compare vfs SSHConfig.KeyPass error, expect:%v, actual:%v", expectSSHConfig.KeyPass, actualSSHConfig.KeyPass)
+	assert(t, expectSSHConfig.HostKey == actualSSHConfig.HostKey, "compare vfs SSHConfig.HostKey error, expect:%v, actual:%v", expectSSHConfig.HostKey, actualSSHConfig.HostKey)
 }
 
 func assert(t *testing.T, ok bool, format string, args ...any) {

--- a/driver/sftp/dir.go
+++ b/driver/sftp/dir.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/no-src/gofs/core"
 	"github.com/no-src/gofs/retry"
 )
 
@@ -17,20 +18,12 @@ type Dir struct {
 }
 
 // NewDir returns a http.FileSystem instance for sftp
-func NewDir(root string, address string, userName string, password string, sshKey string, r retry.Retry, maxTranRate int64) (http.FileSystem, error) {
+func NewDir(root string, address string, sshConfig core.SSHConfig, r retry.Retry, maxTranRate int64) (http.FileSystem, error) {
 	root = strings.TrimSpace(root)
 	if len(root) == 0 {
 		root = "."
 	}
-	userName = strings.TrimSpace(userName)
-	if len(userName) == 0 {
-		return nil, errors.New("invalid username for sftp")
-	}
-	password = strings.TrimSpace(password)
-	if len(password) == 0 {
-		return nil, errors.New("invalid password for sftp")
-	}
-	driver := newSFTPDriver(address, userName, password, sshKey, true, r, maxTranRate)
+	driver := newSFTPDriver(address, sshConfig, true, r, maxTranRate)
 	return &Dir{
 		driver: driver,
 		root:   root,

--- a/driver/sftp/sftp.go
+++ b/driver/sftp/sftp.go
@@ -2,6 +2,7 @@ package sftp
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/no-src/gofs/core"
 	"github.com/no-src/gofs/driver"
 	"github.com/no-src/gofs/internal/rate"
 	"github.com/no-src/gofs/retry"
@@ -24,9 +26,7 @@ type sftpDriver struct {
 	client        *sftp.Client
 	driverName    string
 	remoteAddr    string
-	userName      string
-	password      string
-	sshKey        string
+	sshConfig     core.SSHConfig
 	r             retry.Retry
 	mu            sync.RWMutex
 	online        bool
@@ -35,17 +35,15 @@ type sftpDriver struct {
 }
 
 // NewSFTPDriver get a sftp driver
-func NewSFTPDriver(remoteAddr string, userName string, password string, sshKey string, autoReconnect bool, r retry.Retry, maxTranRate int64) driver.Driver {
-	return newSFTPDriver(remoteAddr, userName, password, sshKey, autoReconnect, r, maxTranRate)
+func NewSFTPDriver(remoteAddr string, sshConfig core.SSHConfig, autoReconnect bool, r retry.Retry, maxTranRate int64) driver.Driver {
+	return newSFTPDriver(remoteAddr, sshConfig, autoReconnect, r, maxTranRate)
 }
 
-func newSFTPDriver(remoteAddr string, userName string, password string, sshKey string, autoReconnect bool, r retry.Retry, maxTranRate int64) *sftpDriver {
+func newSFTPDriver(remoteAddr string, sshConfig core.SSHConfig, autoReconnect bool, r retry.Retry, maxTranRate int64) *sftpDriver {
 	return &sftpDriver{
 		driverName:    "sftp",
 		remoteAddr:    remoteAddr,
-		userName:      userName,
-		password:      password,
-		sshKey:        sshKey,
+		sshConfig:     sshConfig,
 		r:             r,
 		autoReconnect: autoReconnect,
 		maxTranRate:   maxTranRate,
@@ -62,27 +60,36 @@ func (sc *sftpDriver) Connect() error {
 	if sc.online {
 		return nil
 	}
+	if len(sc.sshConfig.Username) == 0 {
+		return errors.New("sftp: the username is required")
+	}
 	c, err := net.Dial("tcp", sc.remoteAddr)
 	if err != nil {
 		return err
 	}
-	// hostKeyCallback, err := sc.getHostKeyCallback()
-	// if err != nil {
-	// 	return err
-	// }
-	signer, e := sc.getSigner()
-	if e != nil {
-		return e
+	hostKeyCallback, err := sc.getHostKeyCallback()
+	if err != nil {
+		return err
 	}
 	conf := ssh.ClientConfig{
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		User:            sc.userName,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-			ssh.Password(sc.password),
-		},
+		HostKeyCallback: hostKeyCallback,
+		User:            sc.sshConfig.Username,
 	}
-	// conf.Auth = append(conf.Auth{}, ssh.Password(sc.password))
+	if len(sc.sshConfig.Key) > 0 {
+		signer, err := sc.getSigner()
+		if err != nil {
+			return err
+		}
+		conf.Auth = append(conf.Auth, ssh.PublicKeys(signer))
+	}
+	if len(sc.sshConfig.Password) > 0 {
+		conf.Auth = append(conf.Auth, ssh.Password(sc.sshConfig.Password))
+	}
+
+	if len(conf.Auth) == 0 {
+		return errors.New("sftp: must set the ssh password or ssh key file")
+	}
+
 	cc, chans, reqs, err := ssh.NewClientConn(c, "", &conf)
 	if err != nil {
 		return err
@@ -95,59 +102,49 @@ func (sc *sftpDriver) Connect() error {
 	return err
 }
 
-func (sc *sftpDriver) getSigner() (signer ssh.Signer, e error) {
-	sc.sshKey = strings.TrimSpace(sc.sshKey)
-	if len(sc.sshKey) == 0 {
-		return
+func (sc *sftpDriver) getSigner() (signer ssh.Signer, err error) {
+	pemBytes, err := os.ReadFile(sc.sshConfig.Key)
+	if err != nil {
+		return nil, err
 	}
 
-	keyFile, e := os.Open(sc.sshKey)
-	if e != nil {
-		return
+	if len(sc.sshConfig.KeyPass) > 0 {
+		return ssh.ParsePrivateKeyWithPassphrase(pemBytes, []byte(sc.sshConfig.KeyPass))
 	}
-	defer keyFile.Close()
-
-	keyData, e := io.ReadAll(keyFile)
-	if e != nil {
-		return
-	}
-
-	signer, e = ssh.ParsePrivateKey(keyData)
-	return
+	return ssh.ParsePrivateKey(pemBytes)
 }
 
-// func (sc *sftpDriver) getHostKeyCallback() (ssh.HostKeyCallback, error) {
-// 	sc.sshKey = strings.TrimSpace(sc.sshKey)
-// 	if len(sc.sshKey) == 0 {
-// 		return ssh.InsecureIgnoreHostKey(), nil
-// 	}
-// 	keyFile, err := os.Open(sc.sshKey)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	defer keyFile.Close()
-// 	keyData, err := io.ReadAll(keyFile)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	keyStat, err := keyFile.Stat()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	keyFileName := strings.ToLower(keyStat.Name())
-// 	var pk ssh.PublicKey
-// 	// ~/.ssh/known_hosts
-// 	if keyFileName == "known_hosts" {
-// 		_, _, pk, _, _, err = ssh.ParseKnownHosts(keyData)
-// 		if err != nil {
-// 			return nil, err
-// 		}
-// 	}
-// 	if pk == nil {
-// 		return nil, fmt.Errorf("invalid ssh key file => %s", keyFileName)
-// 	}
-// 	return ssh.FixedHostKey(pk), nil
-// }
+func (sc *sftpDriver) getHostKeyCallback() (ssh.HostKeyCallback, error) {
+	if len(sc.sshConfig.HostKey) == 0 {
+		return ssh.InsecureIgnoreHostKey(), nil
+	}
+	keyFile, err := os.Open(sc.sshConfig.HostKey)
+	if err != nil {
+		return nil, err
+	}
+	defer keyFile.Close()
+	keyData, err := io.ReadAll(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	keyStat, err := keyFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+	keyFileName := strings.ToLower(keyStat.Name())
+	var pk ssh.PublicKey
+	// ~/.ssh/known_hosts
+	if keyFileName == "known_hosts" {
+		_, _, pk, _, _, err = ssh.ParseKnownHosts(keyData)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if pk == nil {
+		return nil, fmt.Errorf("invalid ssh key file => %s", keyFileName)
+	}
+	return ssh.FixedHostKey(pk), nil
+}
 
 func (sc *sftpDriver) reconnect() error {
 	log.Debug("reconnect to sftp server => %s", sc.remoteAddr)

--- a/driver/sftp/sftp.go
+++ b/driver/sftp/sftp.go
@@ -114,6 +114,7 @@ func (sc *sftpDriver) getSigner() (signer ssh.Signer, err error) {
 
 func (sc *sftpDriver) getHostKeyCallback() (ssh.HostKeyCallback, error) {
 	if len(sc.sshConfig.HostKey) == 0 {
+		log.Warn("sftp: the ssh host key file is not set, the server's host key validation will be disabled, it may cause a MitM attack")
 		return ssh.InsecureIgnoreHostKey(), nil
 	}
 	// ~/.ssh/known_hosts

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -49,9 +49,6 @@ func ParseFlags(args []string) (config conf.Config) {
 	cl.Int64Var(&config.MaxTranRate, "max_tran_rate", 0, "limit the max transmission rate in the server and client sides, and this is an expected value, not an absolute one")
 	cl.BoolVar(&config.DryRun, "dry_run", false, "In dry run mode, gofs is started without actual sync operations")
 
-	// ssh
-	cl.StringVar(&config.SSHKey, "ssh_key", "", "a cryptographic key used for authenticating computers in the SSH protocol")
-
 	// file monitor
 	cl.BoolVar(&config.EnableSyncDelay, "sync_delay", false, "enable sync delay, start sync when the event count is equal or greater than -sync_delay_events, or wait for -sync_delay_time interval time since the last sync")
 	cl.IntVar(&config.SyncDelayEvents, "sync_delay_events", 10, "the maximum event count of sync delay")

--- a/integration/testdata/conf/run-gofs-sftp-pull-client.yaml
+++ b/integration/testdata/conf/run-gofs-sftp-pull-client.yaml
@@ -1,5 +1,4 @@
-source: sftp://127.0.0.1:22?remote_path=/sftp-workspace
+source: sftp://127.0.0.1:22?remote_path=/sftp-workspace&ssh_user=sftp_user&ssh_pass=sftp_pwd
 dest: ./sftp-pull-client/dest
 log_dir: ./sftp-pull-client-logs/
-users: sftp_user|sftp_pwd
 sync_cron: "*/5 * * * * *"

--- a/integration/testdata/conf/run-gofs-sftp-push-client.yaml
+++ b/integration/testdata/conf/run-gofs-sftp-push-client.yaml
@@ -1,4 +1,3 @@
 source: ./sftp-push-client/source
-dest: sftp://127.0.0.1:22?local_sync_disabled=false&path=./sftp-push-client/dest&remote_path=/sftp-workspace
+dest: sftp://127.0.0.1:22?local_sync_disabled=false&path=./sftp-push-client/dest&remote_path=/sftp-workspace&ssh_user=sftp_user&ssh_pass=sftp_pwd
 log_dir: ./sftp-push-client-logs/
-users: sftp_user|sftp_pwd

--- a/scripts/docker-example/run-gofs-docker-sftp-pull-client.sh
+++ b/scripts/docker-example/run-gofs-docker-sftp-pull-client.sh
@@ -9,4 +9,4 @@ export SFTP_SERVER_REMOTE_PATH=/gofs_sftp_server
 export WORKDIR=/workspace
 
 docker run -it --rm -v "$PWD":"$WORKDIR" --name running-gofs-sftp-pull-client nosrc/gofs:latest \
-  gofs -source="sftp://$SFTP_SERVER_ADDR:22?remote_path=$SFTP_SERVER_REMOTE_PATH" -dest="$WORKDIR/sftp-pull-client/dest" -users="sftp_user|sftp_pwd" -sync_once
+  gofs -source="sftp://$SFTP_SERVER_ADDR:22?remote_path=$SFTP_SERVER_REMOTE_PATH&ssh_user=sftp_user&ssh_pass=sftp_pwd" -dest="$WORKDIR/sftp-pull-client/dest" -sync_once

--- a/scripts/docker-example/run-gofs-docker-sftp-push-client.sh
+++ b/scripts/docker-example/run-gofs-docker-sftp-push-client.sh
@@ -9,4 +9,4 @@ export SFTP_SERVER_REMOTE_PATH=/gofs_sftp_server
 export WORKDIR=/workspace
 
 docker run -it --rm -v "$PWD":"$WORKDIR" --name running-gofs-sftp-push-client nosrc/gofs:latest \
-  gofs -source="$WORKDIR/sftp-push-client/source" -dest="sftp://$SFTP_SERVER_ADDR:22?local_sync_disabled=false&path=$WORKDIR/sftp-push-client/dest&remote_path=$SFTP_SERVER_REMOTE_PATH" -users="sftp_user|sftp_pwd"
+  gofs -source="$WORKDIR/sftp-push-client/source" -dest="sftp://$SFTP_SERVER_ADDR:22?local_sync_disabled=false&path=$WORKDIR/sftp-push-client/dest&remote_path=$SFTP_SERVER_REMOTE_PATH&ssh_user=sftp_user&ssh_pass=sftp_pwd"

--- a/server/httpfs/file_server.go
+++ b/server/httpfs/file_server.go
@@ -164,11 +164,7 @@ func initRoute(engine *gin.Engine, opt server.Option, logger log.Logger) error {
 		rootGroup.StaticFS(server.DestRoutePrefix, rate.NewHTTPDir(dest.Path(), opt.MaxTranRate))
 		enableFileApi = true
 	} else if dest.Is(core.SFTP) {
-		if len(opt.Users) == 0 {
-			return errors.New("a user is required for sftp server")
-		}
-		user := opt.Users[0]
-		sftpDir, err := sftp.NewDir(dest.RemotePath(), dest.Addr(), user.UserName(), user.Password(), opt.SSHKey, opt.Retry, opt.MaxTranRate)
+		sftpDir, err := sftp.NewDir(dest.RemotePath(), dest.Addr(), dest.SSHConfig(), opt.Retry, opt.MaxTranRate)
 		if err != nil {
 			return err
 		}

--- a/sync/option.go
+++ b/sync/option.go
@@ -28,7 +28,6 @@ type Option struct {
 	Progress              bool
 	MaxTranRate           int64
 	DryRun                bool
-	SSHKey                string
 	TokenSecret           string
 	Users                 []*auth.User
 	Retry                 retry.Retry
@@ -57,7 +56,6 @@ func NewSyncOption(config conf.Config, users []*auth.User, r retry.Retry, pi ign
 		Progress:              config.Progress,
 		MaxTranRate:           config.MaxTranRate,
 		DryRun:                config.DryRun,
-		SSHKey:                config.SSHKey,
 		TokenSecret:           config.TokenSecret,
 		Users:                 users,
 		Retry:                 r,

--- a/sync/sftp_pull_client_sync.go
+++ b/sync/sftp_pull_client_sync.go
@@ -14,17 +14,12 @@ type sftpPullClientSync struct {
 func NewSftpPullClientSync(opt Option) (Sync, error) {
 	// the fields of option
 	source := opt.Source
-	users := opt.Users
 	chunkSize := opt.ChunkSize
 	maxTranRate := opt.MaxTranRate
 	r := opt.Retry
 
 	if chunkSize <= 0 {
 		return nil, errInvalidChunkSize
-	}
-
-	if len(users) == 0 {
-		return nil, errUserIsRequired
 	}
 
 	ds, err := newDiskSync(opt)
@@ -38,8 +33,7 @@ func NewSftpPullClientSync(opt Option) (Sync, error) {
 		},
 		remoteAddr: source.Addr(),
 	}
-	currentUser := users[0]
-	s.driver = sftp.NewSFTPDriver(s.remoteAddr, currentUser.UserName(), currentUser.Password(), opt.SSHKey, true, r, maxTranRate)
+	s.driver = sftp.NewSFTPDriver(s.remoteAddr, source.SSHConfig(), true, r, maxTranRate)
 
 	err = s.start()
 	if err != nil {

--- a/sync/sftp_push_client_sync.go
+++ b/sync/sftp_push_client_sync.go
@@ -14,17 +14,12 @@ type sftpPushClientSync struct {
 func NewSftpPushClientSync(opt Option) (Sync, error) {
 	// the fields of option
 	dest := opt.Dest
-	users := opt.Users
 	chunkSize := opt.ChunkSize
 	maxTranRate := opt.MaxTranRate
 	r := opt.Retry
 
 	if chunkSize <= 0 {
 		return nil, errInvalidChunkSize
-	}
-
-	if len(users) == 0 {
-		return nil, errUserIsRequired
 	}
 
 	ds, err := newDiskSync(opt)
@@ -40,8 +35,7 @@ func NewSftpPushClientSync(opt Option) (Sync, error) {
 		remoteAddr: dest.Addr(),
 	}
 
-	currentUser := users[0]
-	s.driver = sftp.NewSFTPDriver(s.remoteAddr, currentUser.UserName(), currentUser.Password(), opt.SSHKey, true, r, maxTranRate)
+	s.driver = sftp.NewSFTPDriver(s.remoteAddr, dest.SSHConfig(), true, r, maxTranRate)
 
 	err = s.start()
 	if err != nil {


### PR DESCRIPTION
Problem:
gofs will always throw an error of "invalid ssh key file" when using ssh_key authentication, the problem is from: https://github.com/no-src/gofs/blob/e14bbcb6290010524f68bcd99dc7e74907bb1351/driver/sftp/sftp.go#L109-L120
where `keyFileName` is not `"known_hosts"`.

Refer to the example from golang.org/x/crypto/ssh, we could use `ssh.InsecureIgnoreHostKey()` as HostKeyCallback function temporarily, because seems like `ssh.ParseKnownHosts(keyData)` has some other issue, and the host may not be in `known_hosts` file already.

Instead, the private key file could be parsed by `ssh.ParsePrivateKey()` to be a `ssh.Signer` and then `ssh.PublicKeys()` will convert it to `ssh.AuthMethod`.