### PR TITLE
Update codecov action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,4 +59,3 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.go == '1.21'

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 // VERSION the current program version info
-const VERSION = "v0.8.2"
+const VERSION = "v0.9.0"
 
 // Commit the commit file records the last commit hash value, used by release
 //


### PR DESCRIPTION
> go test -cover now prints coverage summaries for covered packages that do not have their own test files. Prior to Go 1.22 a go test -cover run for such a package would report
> 
> ? mymod/mypack [no test files]
> 
> and now with Go 1.22, functions in the package are treated as uncovered:
> 
> mymod/mypack coverage: 0.0% of statements
> 
> Note that if a package contains no executable code at all, we can't report a meaningful coverage percentage; for such packages the go tool will continue to report that there are no test files.

See [Go 1.22 Release Notes](https://go.dev/doc/go1.22)