### PR TITLE
Fix code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/server/handler/login_handler.go
+++ b/server/handler/login_handler.go
@@ -69,7 +69,7 @@ func (h *loginHandler) Handle(c *gin.Context) {
 		h.logger.Info("login success, userid=%d username=%s remote=%s", loginUser.UserId, loginUser.UserName, c.Request.RemoteAddr)
 		c.Redirect(http.StatusFound, returnUrl)
 	} else {
-		h.logger.Info("login failed, username=%s password=%s remote=%s", userName, password, c.Request.RemoteAddr)
+		h.logger.Info("login failed, username=%s remote=%s", userName, c.Request.RemoteAddr)
 		c.Redirect(http.StatusFound, server.LoginIndexFullRoute)
 	}
 }


### PR DESCRIPTION
Fixes [https://github.com/no-src/gofs/security/code-scanning/8](https://github.com/no-src/gofs/security/code-scanning/8)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. The best way to fix this without changing existing functionality is to remove the password from the log message. This can be done by modifying the log statement to exclude the password while still providing useful information for debugging purposes.

We will edit the file `server/handler/login_handler.go` and modify the log statement on line 72 to remove the password. No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
