### PR TITLE
Fix code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/server/client/login.go
+++ b/server/client/login.go
@@ -20,7 +20,7 @@ func SignIn(httpClient httputil.HttpClient, scheme, host, userName, password str
 	form := url.Values{}
 	form.Set(server.ParamUserName, userName)
 	form.Set(server.ParamPassword, password)
-	logger.Debug("try to auto login file server %s=%s %s=%s", server.ParamUserName, userName, server.ParamPassword, password)
+	logger.Debug("try to auto login file server %s=%s", server.ParamUserName, userName)
 	loginResp, err := httpClient.HttpPostWithoutRedirect(loginUrl, form)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes [https://github.com/no-src/gofs/security/code-scanning/7](https://github.com/no-src/gofs/security/code-scanning/7)

To fix the problem, we should avoid logging the password in clear text. Instead, we can log the attempt to log in without including the password. This way, we maintain the ability to debug login attempts without exposing sensitive information.

- Remove the password from the log message.
- Keep the log message informative by including the username and other non-sensitive information.
- Ensure that the functionality of the code remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
