### PR TITLE
Fix code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/cmd/gofs.go
+++ b/cmd/gofs.go
@@ -337,10 +337,12 @@ func generateRandomUser(cp *conf.Config, logger *logger.Logger) error {
 		} else {
 			cp.Users = randUserStr
 		}
-		logger.Info("generate random users success => [%s]", cp.Users)
+		usernames := extractUsernames(userList)
+		logger.Info("generate random users success => [%s]", usernames)
 	}
 	return nil
 }
+
 
 // checkTLS check cert and key file of the TLS
 func checkTLS(c conf.Config) error {


### PR DESCRIPTION
Fixes [https://github.com/no-src/gofs/security/code-scanning/6](https://github.com/no-src/gofs/security/code-scanning/6)

To fix the problem, we need to ensure that sensitive information, such as user passwords, is not logged in clear text. The best way to fix this issue without changing existing functionality is to modify the logging statement to exclude the password information. Instead of logging the entire `cp.Users` string, we should log only the usernames or other non-sensitive information.

We will modify the `generateRandomUser` function in the `cmd/gofs.go` file to log only the usernames of the generated users. This can be achieved by creating a new function that extracts and returns only the usernames from the user list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
